### PR TITLE
fix: update MediaMetadata entity to use composite keys (id, mediaType)

### DIFF
--- a/app/src/main/java/com/fpf/smartscan/cluster/ClusterManager.kt
+++ b/app/src/main/java/com/fpf/smartscan/cluster/ClusterManager.kt
@@ -41,12 +41,11 @@ class ClusterManager(
     }
 
     suspend fun cluster() {
-        val unclusteredItemIds = mediaMetadataRepository.getUnclusteredItemIds()
+        val unclusteredItemIdsMap = mediaMetadataRepository.getUnclusteredItemIds()
+        val (unclusteredImages, unclusteredVideos) = unclusteredItemIdsMap.keys.partition { unclusteredItemIdsMap[it] == MediaType.IMAGE }
         val unclusterItemEmbeds = mutableListOf<StoredEmbedding>()
-        // unclusteredItemIds includes video and image ids, each store will only return the ones that exist
-        // this is simpler than making 2 separate queries that filter by media type
-        unclusterItemEmbeds.addAll(imageEmbedStore.get(unclusteredItemIds))
-        unclusterItemEmbeds.addAll(videoEmbedStore.get(unclusteredItemIds))
+        unclusterItemEmbeds.addAll(imageEmbedStore.get(unclusteredImages))
+        unclusterItemEmbeds.addAll(videoEmbedStore.get(unclusteredVideos))
         if(unclusterItemEmbeds.isEmpty()) return
 
         val existingClusters: Map<Long, Cluster> = getAllClusters()
@@ -58,7 +57,7 @@ class ClusterManager(
         }
         val clusterer = IncrementalClusterer(existingClusters = existingClusters, defaultThreshold = defaultThreshold)
         val result = clusterer.cluster(unclusterItemEmbeds.associate { it.id to it.embedding})
-        updateClustersAndAssign(result, existingClusters.keys)
+        updateClustersAndAssign(result, existingClusters.keys, unclusteredItemIdsMap)
     }
 
     suspend fun mergeClusters(primaryClusterId: Long, otherClusters: List<Long>){
@@ -72,17 +71,19 @@ class ClusterManager(
         sync(primaryClusterId)
     }
 
-    suspend fun moveItems(itemIds: List<Long>, newClusterId: Long, oldClusterId: Long){
-        clusterCrossRefRepository.upsertClusterCrossRefs(itemIds, newClusterId)
+    suspend fun moveItems(items: Set<MediaItem>, newClusterId: Long, oldClusterId: Long){
+        val crossRefs = items.map { ClusterCrossRef(clusterId = newClusterId, mediaId = it.id, mediaType = it.type) }
+        clusterCrossRefRepository.upsertClusterCrossRefs(crossRefs)
         listOf(oldClusterId, newClusterId).forEach { sync(it) }
     }
 
     suspend fun createNewClusterAndMoveItems(items: Set<MediaItem>, newClusterLabel: String, oldClusterId: Long){
+        val itemsMap = items.associate { it.id to it.type }
         val (imageItems, videoItems) = items.partition { it.type == MediaType.IMAGE }
         val itemEmbeds = mutableListOf<StoredEmbedding>()
         itemEmbeds.addAll(imageEmbedStore.get(imageItems.map{it.id}))
         itemEmbeds.addAll(videoEmbedStore.get(videoItems.map{it.id}))
-        createNewCluster(itemEmbeds, newClusterLabel)
+        createNewCluster(itemEmbeds, newClusterLabel, itemsMap)
         sync(oldClusterId)
     }
 
@@ -119,7 +120,7 @@ class ClusterManager(
         } else emptyMap()
     }
 
-    private suspend fun updateClustersAndAssign(clusterResult: ClusterResult, existingClusterIds: Set<Long>) {
+    private suspend fun updateClustersAndAssign(clusterResult: ClusterResult, existingClusterIds: Set<Long>, mediaTypeMap: Map<Long, MediaType>) {
         val (existingClusters, newClusters) = clusterResult.clusters.values.partition { it.clusterId in existingClusterIds }
 
         val existingMetadata = existingClusters.map {
@@ -164,11 +165,14 @@ class ClusterManager(
         clusterEmbedStore.add(newEmbeds)
         clusterEmbedStore.update(existingEmbeds)
 
-        val crossRefs = clusterResult.assignments.map { ClusterCrossRef(clusterId = it.value, mediaId = it.key) }
+        val crossRefs = clusterResult.assignments.mapNotNull {
+            val mediaType =  mediaTypeMap[it.key]?: return@mapNotNull null
+            ClusterCrossRef(clusterId = it.value, mediaId = it.key, mediaType = mediaType)
+        }
         clusterCrossRefRepository.upsertClusterCrossRefs(crossRefs)
     }
 
-    private suspend fun createNewCluster(itemEmbeds: List<StoredEmbedding>, clusterLabel: String): Long{
+    private suspend fun createNewCluster(itemEmbeds: List<StoredEmbedding>, clusterLabel: String, itemsMediaTypeMap: Map<Long, MediaType>): Long{
         val (metadata, prototype ) = if(itemEmbeds.size == 1) {
             val defaultThreshold = getDefaultThreshold(getAllClusters())
             val meta = MediaClusterMetadata(
@@ -199,7 +203,12 @@ class ClusterManager(
         )
         clusterEmbedStore.add(listOf(clusterEmbed))
         clusterMetadataRepository.insertMetadata(metadata)
-        clusterCrossRefRepository.upsertClusterCrossRefs(itemEmbeds.map { it.id }, clusterEmbed.id)
+
+        val crossRefs = itemEmbeds.mapNotNull {
+            val mediaType = itemsMediaTypeMap[it.id]?: return@mapNotNull null
+            ClusterCrossRef(mediaId = it.id, clusterId = clusterEmbed.id, mediaType = mediaType)
+        }
+        clusterCrossRefRepository.upsertClusterCrossRefs(crossRefs)
         return clusterEmbed.id
     }
     private fun getDefaultThresholdFromSample(items: List<StoredEmbedding>, n: Int): Float{

--- a/app/src/main/java/com/fpf/smartscan/data/DataSyncHelper.kt
+++ b/app/src/main/java/com/fpf/smartscan/data/DataSyncHelper.kt
@@ -146,6 +146,7 @@ object DataSyncHelper {
             TagCrossRef(
                 mediaId = it.imageId,
                 tagId = tagId,
+                mediaType = MediaType.IMAGE
             )
         }
 
@@ -176,6 +177,7 @@ object DataSyncHelper {
             TagCrossRef(
                 mediaId = it.videoId,
                 tagId = tagId,
+                mediaType = MediaType.VIDEO
             )
         }
 

--- a/app/src/main/java/com/fpf/smartscan/data/DataSyncHelper.kt
+++ b/app/src/main/java/com/fpf/smartscan/data/DataSyncHelper.kt
@@ -220,7 +220,7 @@ object DataSyncHelper {
         // Purge stale media - Embed store used as source of truth
         val mediaToPurge = existingIdsFromEmbedStore.filterNot {it in accessibleMediaIds}
         if(mediaToPurge.isNotEmpty()){
-            removeStaleMedia(mediaToPurge, store = store, mediaMetadataRepository)
+            removeStaleMedia(mediaToPurge, mediaType, store = store, mediaMetadataRepository)
             existingIdsFromEmbedStore.removeAll(mediaToPurge)
             existingIdsFromMetadata.removeAll(mediaToPurge)
             store.save()

--- a/app/src/main/java/com/fpf/smartscan/data/MediaDatabase.kt
+++ b/app/src/main/java/com/fpf/smartscan/data/MediaDatabase.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
 import com.fpf.smartscan.data.clusters.ClusterCrossRef
 import com.fpf.smartscan.data.clusters.ClusterCrossRefDao
 import com.fpf.smartscan.data.clusters.MediaClusterMetadata
@@ -30,6 +31,7 @@ import com.fpf.smartscan.data.tags.TagDao
     version = 4,
     exportSchema = false
 )
+@TypeConverters(MediaTypeConverter::class)
 abstract class MediaDatabase : RoomDatabase() {
 
     abstract fun clusterCrossRefDao(): ClusterCrossRefDao

--- a/app/src/main/java/com/fpf/smartscan/data/MediaIdType.kt
+++ b/app/src/main/java/com/fpf/smartscan/data/MediaIdType.kt
@@ -1,0 +1,8 @@
+package com.fpf.smartscan.data
+
+import com.fpf.smartscan.media.MediaType
+
+data class MediaIdType(
+    val id: Long,
+    val type: MediaType
+)

--- a/app/src/main/java/com/fpf/smartscan/data/MediaTypeConverter.kt
+++ b/app/src/main/java/com/fpf/smartscan/data/MediaTypeConverter.kt
@@ -6,12 +6,13 @@ import com.fpf.smartscan.media.MediaType
 class MediaTypeConverter {
 
     @TypeConverter
-    fun fromMediaType(type: MediaType): String {
-        return type.name
+    fun fromMediaType(type: MediaType): Int {
+        return type.code
     }
 
     @TypeConverter
-    fun toMediaType(value: String): MediaType {
-        return MediaType.valueOf(value)
+    fun toMediaType(value: Int): MediaType {
+        return MediaType.entries.firstOrNull { it.code == value }
+            ?: throw IllegalArgumentException("Unknown MediaType code: $value")
     }
 }

--- a/app/src/main/java/com/fpf/smartscan/data/clusters/ClusterCrossRef.kt
+++ b/app/src/main/java/com/fpf/smartscan/data/clusters/ClusterCrossRef.kt
@@ -3,13 +3,14 @@ package com.fpf.smartscan.data.clusters
 import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
-import androidx.room.PrimaryKey
 import androidx.room.TypeConverters
 import com.fpf.smartscan.data.MediaTypeConverter
 import com.fpf.smartscan.data.metadata.MediaMetadata
+import com.fpf.smartscan.media.MediaType
 
 @Entity(
     tableName = "media_cluster_crossref",
+    primaryKeys = ["mediaId", "mediaType"],
     foreignKeys = [
         ForeignKey(
             entity = MediaClusterMetadata::class,
@@ -19,16 +20,18 @@ import com.fpf.smartscan.data.metadata.MediaMetadata
         ),
         ForeignKey(
             entity = MediaMetadata::class,
-            parentColumns = ["id"],
-            childColumns = ["mediaId"],
+            parentColumns = ["id", "type"],
+            childColumns = ["mediaId", "mediaType"],
             onDelete = ForeignKey.CASCADE
         )
     ],
-    indices = [Index("clusterId")]
+    indices = [
+        Index(value = ["clusterId"])
+    ]
 )
 @TypeConverters(MediaTypeConverter::class)
 data class ClusterCrossRef(
-    @PrimaryKey
     val mediaId: Long,
-    val clusterId: Long,
+    val mediaType: MediaType,
+    val clusterId: Long
 )

--- a/app/src/main/java/com/fpf/smartscan/data/clusters/ClusterCrossRef.kt
+++ b/app/src/main/java/com/fpf/smartscan/data/clusters/ClusterCrossRef.kt
@@ -3,8 +3,6 @@ package com.fpf.smartscan.data.clusters
 import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
-import androidx.room.TypeConverters
-import com.fpf.smartscan.data.MediaTypeConverter
 import com.fpf.smartscan.data.metadata.MediaMetadata
 import com.fpf.smartscan.media.MediaType
 
@@ -29,7 +27,6 @@ import com.fpf.smartscan.media.MediaType
         Index(value = ["clusterId"])
     ]
 )
-@TypeConverters(MediaTypeConverter::class)
 data class ClusterCrossRef(
     val mediaId: Long,
     val mediaType: MediaType,

--- a/app/src/main/java/com/fpf/smartscan/data/clusters/ClusterCrossRefDao.kt
+++ b/app/src/main/java/com/fpf/smartscan/data/clusters/ClusterCrossRefDao.kt
@@ -36,12 +36,6 @@ interface ClusterCrossRefDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsert(crossRefs: List<ClusterCrossRef>)
 
-    @Query("DELETE FROM media_cluster_crossref WHERE clusterId IN (:clusterIds)")
-    suspend fun deleteByClusterIds(clusterIds: List<Long>)
-
-    @Query("DELETE FROM media_cluster_crossref WHERE mediaId IN (:mediaIds)")
-    suspend fun deleteByMediaIds(mediaIds: List<Long>)
-
     @Query("DELETE FROM media_cluster_crossref")
     suspend fun clear()
 

--- a/app/src/main/java/com/fpf/smartscan/data/clusters/ClusterCrossRefRepository.kt
+++ b/app/src/main/java/com/fpf/smartscan/data/clusters/ClusterCrossRefRepository.kt
@@ -16,11 +16,6 @@ class ClusterCrossRefRepository(private val dao: ClusterCrossRefDao) {
         refreshCache = true
     }
 
-    suspend fun upsertClusterCrossRefs(itemIds: List<Long>, clusterId: Long) {
-        val crossRefs = itemIds.map { ClusterCrossRef(clusterId = clusterId, mediaId = it) }
-        upsertClusterCrossRefs(crossRefs)
-    }
-
     suspend fun deleteByClusterIds(ids: List<Long>) {
         dao.deleteByClusterIds(ids)
         refreshCache = true

--- a/app/src/main/java/com/fpf/smartscan/data/clusters/ClusterCrossRefRepository.kt
+++ b/app/src/main/java/com/fpf/smartscan/data/clusters/ClusterCrossRefRepository.kt
@@ -16,14 +16,6 @@ class ClusterCrossRefRepository(private val dao: ClusterCrossRefDao) {
         refreshCache = true
     }
 
-    suspend fun deleteByClusterIds(ids: List<Long>) {
-        dao.deleteByClusterIds(ids)
-        refreshCache = true
-    }
-    suspend fun deleteByMediaIds(ids: List<Long>) {
-        dao.deleteByMediaIds(ids)
-        refreshCache = true
-    }
     suspend fun clear() {
         refreshCache = false
         clusterToMediaIdsMap.clear()
@@ -32,6 +24,9 @@ class ClusterCrossRefRepository(private val dao: ClusterCrossRefDao) {
     suspend fun count() = dao.count()
     suspend fun count(clusterId: Long) = dao.countByClusterId(clusterId)
 
+    //NOTE: may require changing foreign key is now (id, type) though this may not be necessary
+    // because its only used in search and search around handles media types separate meaninng any collision between
+    // MediaStre video ids and image ids arent possible.
     suspend fun getClusterToMediaIdsMap(): Map<Long, MutableSet<Long>> {
         if(refreshCache){
             clusterToMediaIdsMap.clear()

--- a/app/src/main/java/com/fpf/smartscan/data/metadata/MediaMetadata.kt
+++ b/app/src/main/java/com/fpf/smartscan/data/metadata/MediaMetadata.kt
@@ -3,9 +3,6 @@ package com.fpf.smartscan.data.metadata
 
 import androidx.room.Entity
 import androidx.room.Index
-import androidx.room.PrimaryKey
-import androidx.room.TypeConverters
-import com.fpf.smartscan.data.MediaTypeConverter
 import com.fpf.smartscan.media.MediaType
 
 @Entity(
@@ -15,7 +12,6 @@ import com.fpf.smartscan.media.MediaType
         Index(value = ["dateAdded"]),
         Index(value = ["type", "dateAdded"])
     ])
-@TypeConverters(MediaTypeConverter::class)
 data class MediaMetadata(
     val id: Long,
     val type: MediaType,

--- a/app/src/main/java/com/fpf/smartscan/data/metadata/MediaMetadata.kt
+++ b/app/src/main/java/com/fpf/smartscan/data/metadata/MediaMetadata.kt
@@ -9,15 +9,14 @@ import com.fpf.smartscan.data.MediaTypeConverter
 import com.fpf.smartscan.media.MediaType
 
 @Entity(
+    primaryKeys = ["id", "type"],
     tableName = "media_metadata",
     indices = [
         Index(value = ["dateAdded"]),
-        Index(value = ["type"]),
         Index(value = ["type", "dateAdded"])
     ])
 @TypeConverters(MediaTypeConverter::class)
 data class MediaMetadata(
-    @PrimaryKey
     val id: Long,
     val type: MediaType,
     val dateAdded: Long,

--- a/app/src/main/java/com/fpf/smartscan/data/metadata/MediaMetadataDao.kt
+++ b/app/src/main/java/com/fpf/smartscan/data/metadata/MediaMetadataDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
+import com.fpf.smartscan.data.MediaIdType
 import com.fpf.smartscan.media.MediaType
 
 @Dao
@@ -22,16 +23,23 @@ interface MediaMetadataDao {
     @Update
     suspend fun update(item: MediaMetadata)
 
-    @Query("SELECT id FROM media_metadata")
-    suspend fun getAllIds(): List<Long>
     @Query("SELECT * FROM media_metadata WHERE id IN (:mediaIds)")
     suspend fun getByIds(mediaIds: List<Long>): List<MediaMetadata>
 
     @Query("SELECT * FROM media_metadata WHERE type = :type")
     suspend fun getByType(type: MediaType): List<MediaMetadata>
 
-    @Query("SELECT id FROM media_metadata WHERE id NOT IN (SELECT mediaId FROM media_cluster_crossref)")
-    suspend fun getUnclusteredItemIds(): List<Long>
+    @Query("""
+        SELECT id, type
+        FROM media_metadata
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM media_cluster_crossref c
+            WHERE c.mediaId = media_metadata.id
+              AND c.mediaType = media_metadata.type
+        )
+    """)
+    suspend fun getUnclusteredItemIds(): List<MediaIdType>
 
     @Query("""
         SELECT m.*

--- a/app/src/main/java/com/fpf/smartscan/data/metadata/MediaMetadataDao.kt
+++ b/app/src/main/java/com/fpf/smartscan/data/metadata/MediaMetadataDao.kt
@@ -23,11 +23,14 @@ interface MediaMetadataDao {
     @Update
     suspend fun update(item: MediaMetadata)
 
-    @Query("SELECT * FROM media_metadata WHERE id IN (:mediaIds)")
-    suspend fun getByIds(mediaIds: List<Long>): List<MediaMetadata>
+
+    @Query("SELECT * FROM media_metadata WHERE id IN (:mediaIds) AND type = :type")
+    suspend fun getByIds(mediaIds: List<Long>, type: MediaType): List<MediaMetadata>
+
 
     @Query("SELECT * FROM media_metadata WHERE type = :type")
     suspend fun getByType(type: MediaType): List<MediaMetadata>
+
 
     @Query("""
         SELECT id, type
@@ -41,29 +44,40 @@ interface MediaMetadataDao {
     """)
     suspend fun getUnclusteredItemIds(): List<MediaIdType>
 
+
+    // TAG QUERIES
+
     @Query("""
         SELECT m.*
         FROM media_metadata m
-        INNER JOIN tag_crossref c ON c.mediaId = m.id
+        INNER JOIN tag_crossref c 
+            ON c.mediaId = m.id
+            AND c.mediaType = m.type
         WHERE c.tagId = :tagId
         ORDER BY m.dateAdded DESC, m.id DESC
         LIMIT :limit OFFSET :offset
     """)
     suspend fun getByTag(tagId: Long, limit: Int, offset: Int): List<MediaMetadata>
 
-    @Query("""
-    SELECT m.*
-    FROM media_metadata m
-    INNER JOIN tag_crossref c ON c.mediaId = m.id
-    WHERE c.tagId = :tagId
-    ORDER BY m.dateAdded DESC, m.id DESC
-""")
-    suspend fun getByTag(tagId: Long): List<MediaMetadata>
 
     @Query("""
         SELECT m.*
         FROM media_metadata m
-        INNER JOIN tag_crossref c ON c.mediaId = m.id
+        INNER JOIN tag_crossref c 
+            ON c.mediaId = m.id
+            AND c.mediaType = m.type
+        WHERE c.tagId = :tagId
+        ORDER BY m.dateAdded DESC, m.id DESC
+    """)
+    suspend fun getByTag(tagId: Long): List<MediaMetadata>
+
+
+    @Query("""
+        SELECT m.*
+        FROM media_metadata m
+        INNER JOIN tag_crossref c 
+            ON c.mediaId = m.id
+            AND c.mediaType = m.type
         WHERE c.tagId = :tagId
           AND m.type = :type
         ORDER BY m.dateAdded DESC, m.id DESC
@@ -75,112 +89,160 @@ interface MediaMetadataDao {
     @Query("""
         SELECT m.*
         FROM media_metadata m
-        INNER JOIN tag_crossref c ON c.mediaId = m.id
+        INNER JOIN tag_crossref c 
+            ON c.mediaId = m.id
+            AND c.mediaType = m.type
         WHERE c.tagId = :tagId
           AND m.type = :type
         ORDER BY m.dateAdded DESC, m.id DESC
     """)
-    suspend fun getByTag(tagId: Long, type: MediaType ): List<MediaMetadata>
+    suspend fun getByTag(tagId: Long, type: MediaType): List<MediaMetadata>
 
-    @Query("""
-    SELECT m.*
-    FROM media_metadata m
-    INNER JOIN tag_crossref c ON c.mediaId = m.id
-    WHERE c.tagId = :tagId
-      AND (:startDate IS NULL OR m.dateAdded >= :startDate)
-      AND (:endDate IS NULL OR m.dateAdded <= :endDate)
-    ORDER BY m.dateAdded DESC, m.id DESC
-    LIMIT :limit OFFSET :offset
-""")
-    suspend fun getByTag(tagId: Long, startDate: Long?, endDate: Long?, limit: Int, offset: Int): List<MediaMetadata>
-
-    @Query("""
-    SELECT m.*
-    FROM media_metadata m
-    INNER JOIN tag_crossref c ON c.mediaId = m.id
-    WHERE c.tagId = :tagId
-      AND m.type = :type
-      AND (:startDate IS NULL OR m.dateAdded >= :startDate)
-      AND (:endDate IS NULL OR m.dateAdded <= :endDate)
-    ORDER BY m.dateAdded DESC, m.id DESC
-    LIMIT :limit OFFSET :offset
-""")
-    suspend fun getByTag(tagId: Long, type: MediaType, startDate: Long?, endDate: Long?, limit: Int, offset: Int): List<MediaMetadata>
-
-    @Query("""
-    SELECT m.*
-    FROM media_metadata m
-    INNER JOIN tag_crossref c ON c.mediaId = m.id
-    WHERE c.tagId = :tagId
-      AND m.type = :type
-      AND (:startDate IS NULL OR m.dateAdded >= :startDate)
-      AND (:endDate IS NULL OR m.dateAdded <= :endDate)
-    ORDER BY m.dateAdded DESC, m.id DESC
-""")
-    suspend fun getByTag(tagId: Long, type: MediaType, startDate: Long?, endDate: Long?): List<MediaMetadata>
-
-    @Query("""
-        SELECT COUNT(*)
-        FROM media_metadata m
-        INNER JOIN tag_crossref c ON c.mediaId = m.id
-        WHERE c.tagId = :tagId
-    """)
-    suspend fun countByTag(tagId: Long): Int
-
-    @Query("""
-        SELECT COUNT(*)
-        FROM media_metadata m
-        INNER JOIN tag_crossref c ON c.mediaId = m.id
-        WHERE c.tagId = :tagId
-          AND m.type = :type
-    """)
-
-    suspend fun countByTag(tagId: Long, type: MediaType): Int
-    @Query("""
-    SELECT COUNT(*)
-    FROM media_metadata m
-    INNER JOIN tag_crossref c ON c.mediaId = m.id
-    WHERE c.tagId = :tagId
-      AND (:startDate IS NULL OR m.dateAdded >= :startDate)
-      AND (:endDate IS NULL OR m.dateAdded <= :endDate)
-""")
-
-    suspend fun countByTag(tagId: Long, startDate: Long?, endDate: Long?): Int
-
-    @Query("""
-    SELECT COUNT(*)
-    FROM media_metadata m
-    INNER JOIN tag_crossref c ON c.mediaId = m.id
-    WHERE c.tagId = :tagId
-      AND m.type = :type
-      AND (:startDate IS NULL OR m.dateAdded >= :startDate)
-      AND (:endDate IS NULL OR m.dateAdded <= :endDate)
-""")
-    suspend fun countByTag(tagId: Long, type: MediaType, startDate: Long?, endDate: Long?): Int
 
     @Query("""
         SELECT m.*
         FROM media_metadata m
-        INNER JOIN media_cluster_crossref c ON c.mediaId = m.id
+        INNER JOIN tag_crossref c 
+            ON c.mediaId = m.id
+            AND c.mediaType = m.type
+        WHERE c.tagId = :tagId
+          AND (:startDate IS NULL OR m.dateAdded >= :startDate)
+          AND (:endDate IS NULL OR m.dateAdded <= :endDate)
+        ORDER BY m.dateAdded DESC, m.id DESC
+        LIMIT :limit OFFSET :offset
+    """)
+    suspend fun getByTag(tagId: Long, startDate: Long?, endDate: Long?, limit: Int, offset: Int): List<MediaMetadata>
+
+
+    @Query("""
+        SELECT m.*
+        FROM media_metadata m
+        INNER JOIN tag_crossref c 
+            ON c.mediaId = m.id
+            AND c.mediaType = m.type
+        WHERE c.tagId = :tagId
+          AND m.type = :type
+          AND (:startDate IS NULL OR m.dateAdded >= :startDate)
+          AND (:endDate IS NULL OR m.dateAdded <= :endDate)
+        ORDER BY m.dateAdded DESC, m.id DESC
+        LIMIT :limit OFFSET :offset
+    """)
+    suspend fun getByTag(tagId: Long, type: MediaType, startDate: Long?, endDate: Long?, limit: Int, offset: Int): List<MediaMetadata>
+
+
+    @Query("""
+        SELECT m.*
+        FROM media_metadata m
+        INNER JOIN tag_crossref c 
+            ON c.mediaId = m.id
+            AND c.mediaType = m.type
+        WHERE c.tagId = :tagId
+          AND (:startDate IS NULL OR m.dateAdded >= :startDate)
+          AND (:endDate IS NULL OR m.dateAdded <= :endDate)
+        ORDER BY m.dateAdded DESC, m.id DESC
+    """)
+    suspend fun getByTag(tagId: Long, startDate: Long?, endDate: Long?): List<MediaMetadata>
+
+
+    @Query("""
+        SELECT m.*
+        FROM media_metadata m
+        INNER JOIN tag_crossref c 
+            ON c.mediaId = m.id
+            AND c.mediaType = m.type
+        WHERE c.tagId = :tagId
+          AND m.type = :type
+          AND (:startDate IS NULL OR m.dateAdded >= :startDate)
+          AND (:endDate IS NULL OR m.dateAdded <= :endDate)
+        ORDER BY m.dateAdded DESC, m.id DESC
+    """)
+    suspend fun getByTag(tagId: Long, type: MediaType, startDate: Long?, endDate: Long?): List<MediaMetadata>
+
+
+    @Query("""
+        SELECT COUNT(*)
+        FROM media_metadata m
+        INNER JOIN tag_crossref c
+            ON c.mediaId = m.id
+            AND c.mediaType = m.type
+        WHERE c.tagId = :tagId
+    """)
+    suspend fun countByTag(tagId: Long): Int
+
+
+    @Query("""
+        SELECT COUNT(*)
+        FROM media_metadata m
+        INNER JOIN tag_crossref c
+            ON c.mediaId = m.id
+            AND c.mediaType = m.type
+        WHERE c.tagId = :tagId
+          AND m.type = :type
+    """)
+    suspend fun countByTag(tagId: Long, type: MediaType): Int
+
+
+    @Query("""
+        SELECT COUNT(*)
+        FROM media_metadata m
+        INNER JOIN tag_crossref c
+            ON c.mediaId = m.id
+            AND c.mediaType = m.type
+        WHERE c.tagId = :tagId
+          AND (:startDate IS NULL OR m.dateAdded >= :startDate)
+          AND (:endDate IS NULL OR m.dateAdded <= :endDate)
+    """)
+    suspend fun countByTag(tagId: Long, startDate: Long?, endDate: Long?): Int
+
+
+    @Query("""
+        SELECT COUNT(*)
+        FROM media_metadata m
+        INNER JOIN tag_crossref c
+            ON c.mediaId = m.id
+            AND c.mediaType = m.type
+        WHERE c.tagId = :tagId
+          AND m.type = :type
+          AND (:startDate IS NULL OR m.dateAdded >= :startDate)
+          AND (:endDate IS NULL OR m.dateAdded <= :endDate)
+    """)
+    suspend fun countByTag(tagId: Long, type: MediaType, startDate: Long?, endDate: Long?): Int
+
+
+    // CLUSTER QUERIES
+
+    @Query("""
+        SELECT m.*
+        FROM media_metadata m
+        INNER JOIN media_cluster_crossref c
+            ON c.mediaId = m.id
+            AND c.mediaType = m.type
         WHERE c.clusterId = :clusterId
         ORDER BY m.dateAdded DESC, m.id DESC
         LIMIT :limit OFFSET :offset
     """)
     suspend fun getByCluster(clusterId: Long, limit: Int, offset: Int): List<MediaMetadata>
 
-    @Query("""
-    SELECT m.*
-    FROM media_metadata m
-    INNER JOIN media_cluster_crossref c ON c.mediaId = m.id
-    WHERE c.clusterId = :clusterId
-    ORDER BY m.dateAdded DESC, m.id DESC
-""")
-    suspend fun getByCluster(clusterId: Long): List<MediaMetadata>
 
     @Query("""
         SELECT m.*
         FROM media_metadata m
-        INNER JOIN media_cluster_crossref c ON c.mediaId = m.id
+        INNER JOIN media_cluster_crossref c
+            ON c.mediaId = m.id
+            AND c.mediaType = m.type
+        WHERE c.clusterId = :clusterId
+        ORDER BY m.dateAdded DESC, m.id DESC
+    """)
+    suspend fun getByCluster(clusterId: Long): List<MediaMetadata>
+
+
+
+    @Query("""
+        SELECT m.*
+        FROM media_metadata m
+        INNER JOIN media_cluster_crossref c
+            ON c.mediaId = m.id
+            AND c.mediaType = m.type
         WHERE c.clusterId = :clusterId
           AND m.type = :type
         ORDER BY m.dateAdded DESC, m.id DESC
@@ -188,22 +250,27 @@ interface MediaMetadataDao {
     """)
     suspend fun getByCluster(clusterId: Long, type: MediaType, limit: Int, offset: Int): List<MediaMetadata>
 
+
     @Query("""
-    SELECT m.*
-    FROM media_metadata m
-    INNER JOIN media_cluster_crossref c ON c.mediaId = m.id
-    WHERE c.clusterId = :clusterId
-      AND (:startDate IS NULL OR m.dateAdded >= :startDate)
-      AND (:endDate IS NULL OR m.dateAdded <= :endDate)
-    ORDER BY m.dateAdded DESC, m.id DESC
-    LIMIT :limit OFFSET :offset
-""")
+        SELECT m.*
+        FROM media_metadata m
+        INNER JOIN media_cluster_crossref c
+            ON c.mediaId = m.id
+            AND c.mediaType = m.type
+        WHERE c.clusterId = :clusterId
+          AND (:startDate IS NULL OR m.dateAdded >= :startDate)
+          AND (:endDate IS NULL OR m.dateAdded <= :endDate)
+        ORDER BY m.dateAdded DESC, m.id DESC
+        LIMIT :limit OFFSET :offset
+    """)
     suspend fun getByCluster(clusterId: Long, startDate: Long?, endDate: Long?, limit: Int, offset: Int): List<MediaMetadata>
 
     @Query("""
     SELECT m.*
     FROM media_metadata m
-    INNER JOIN media_cluster_crossref c ON c.mediaId = m.id
+    INNER JOIN media_cluster_crossref c
+        ON c.mediaId = m.id
+        AND c.mediaType = m.type
     WHERE c.clusterId = :clusterId
       AND m.type = :type
       AND (:startDate IS NULL OR m.dateAdded >= :startDate)
@@ -216,67 +283,84 @@ interface MediaMetadataDao {
     @Query("""
         SELECT COUNT(*)
         FROM media_metadata m
-        INNER JOIN media_cluster_crossref c ON c.mediaId = m.id
+        INNER JOIN media_cluster_crossref c
+            ON c.mediaId = m.id
+            AND c.mediaType = m.type
         WHERE c.clusterId = :clusterId
     """)
     suspend fun countByCluster(clusterId: Long): Int
 
+
     @Query("""
         SELECT COUNT(*)
         FROM media_metadata m
-        INNER JOIN media_cluster_crossref c ON c.mediaId = m.id
+        INNER JOIN media_cluster_crossref c
+            ON c.mediaId = m.id
+            AND c.mediaType = m.type
         WHERE c.clusterId = :clusterId
           AND m.type = :type
     """)
     suspend fun countByCluster(clusterId: Long, type: MediaType): Int
 
+
     @Query("""
-    SELECT COUNT(*)
-    FROM media_metadata m
-    INNER JOIN media_cluster_crossref c ON c.mediaId = m.id
-    WHERE c.clusterId = :clusterId
-      AND (:startDate IS NULL OR m.dateAdded >= :startDate)
-      AND (:endDate IS NULL OR m.dateAdded <= :endDate)
-""")
+        SELECT COUNT(*)
+        FROM media_metadata m
+        INNER JOIN media_cluster_crossref c
+            ON c.mediaId = m.id
+            AND c.mediaType = m.type
+        WHERE c.clusterId = :clusterId
+          AND (:startDate IS NULL OR m.dateAdded >= :startDate)
+          AND (:endDate IS NULL OR m.dateAdded <= :endDate)
+    """)
     suspend fun countByCluster(clusterId: Long, startDate: Long?, endDate: Long?): Int
 
 
     @Query("""
-    SELECT COUNT(*)
-    FROM media_metadata m
-    INNER JOIN media_cluster_crossref c ON c.mediaId = m.id
-    WHERE c.clusterId = :clusterId
-      AND m.type = :type
-      AND (:startDate IS NULL OR m.dateAdded >= :startDate)
-      AND (:endDate IS NULL OR m.dateAdded <= :endDate)
-""")
+        SELECT COUNT(*)
+        FROM media_metadata m
+        INNER JOIN media_cluster_crossref c
+            ON c.mediaId = m.id
+            AND c.mediaType = m.type
+        WHERE c.clusterId = :clusterId
+          AND m.type = :type
+          AND (:startDate IS NULL OR m.dateAdded >= :startDate)
+          AND (:endDate IS NULL OR m.dateAdded <= :endDate)
+    """)
     suspend fun countByCluster(clusterId: Long, type: MediaType, startDate: Long?, endDate: Long?): Int
 
+
+    // DELETE
+
     @Query("""
-    DELETE FROM media_metadata
-    WHERE id IN (
-        SELECT mediaId
-        FROM tag_crossref
-        WHERE tagId = :tagId
-    )
-""")
+        DELETE FROM media_metadata
+        WHERE (id, type) IN (
+            SELECT mediaId, mediaType
+            FROM tag_crossref
+            WHERE tagId = :tagId
+        )
+    """)
     suspend fun deleteByTag(tagId: Long)
 
-    @Query("""
-    DELETE FROM media_metadata
-    WHERE id IN (
-        SELECT mediaId
-        FROM media_cluster_crossref
-        WHERE clusterId = :clusterId
-    )
-""")
-    suspend fun deleteByCluster(clusterId: Long)
 
     @Query("""
-    DELETE FROM media_metadata
-    WHERE id IN (:mediaIds)
-""")
-    suspend fun deleteByIds(mediaIds: List<Long>)
+        DELETE FROM media_metadata
+        WHERE (id, type) IN (
+            SELECT mediaId, mediaType
+            FROM media_cluster_crossref
+            WHERE clusterId = :clusterId
+        )
+    """)
+    suspend fun deleteByCluster(clusterId: Long)
+
+
+    @Query("""
+        DELETE FROM media_metadata
+        WHERE id IN (:mediaIds)
+          AND type = :type
+    """)
+    suspend fun deleteByIds(mediaIds: List<Long>, type: MediaType)
+
 
     @Query("DELETE FROM media_metadata")
     suspend fun clear()

--- a/app/src/main/java/com/fpf/smartscan/data/metadata/MediaMetadataRepository.kt
+++ b/app/src/main/java/com/fpf/smartscan/data/metadata/MediaMetadataRepository.kt
@@ -1,5 +1,6 @@
 package com.fpf.smartscan.data.metadata
 
+import com.fpf.smartscan.data.MediaIdType
 import com.fpf.smartscan.media.MediaType
 
 class MediaMetadataRepository(
@@ -13,9 +14,7 @@ class MediaMetadataRepository(
 
     suspend fun update(item: MediaMetadata) = dao.update(item)
 
-    suspend fun getAllIds(): List<Long> = dao.getAllIds()
-
-    suspend fun getUnclusteredItemIds(): List<Long> = dao.getUnclusteredItemIds()
+    suspend fun getUnclusteredItemIds(): Map<Long, MediaType> = dao.getUnclusteredItemIds().associate { it.id to it.type }
 
     suspend fun getByIds(mediaIds: List<Long>): List<MediaMetadata> = dao.getByIds(mediaIds)
     suspend fun getByType(type: MediaType): List<MediaMetadata> = dao.getByType(type)

--- a/app/src/main/java/com/fpf/smartscan/data/metadata/MediaMetadataRepository.kt
+++ b/app/src/main/java/com/fpf/smartscan/data/metadata/MediaMetadataRepository.kt
@@ -1,6 +1,5 @@
 package com.fpf.smartscan.data.metadata
 
-import com.fpf.smartscan.data.MediaIdType
 import com.fpf.smartscan.media.MediaType
 
 class MediaMetadataRepository(
@@ -16,7 +15,7 @@ class MediaMetadataRepository(
 
     suspend fun getUnclusteredItemIds(): Map<Long, MediaType> = dao.getUnclusteredItemIds().associate { it.id to it.type }
 
-    suspend fun getByIds(mediaIds: List<Long>): List<MediaMetadata> = dao.getByIds(mediaIds)
+    suspend fun getByIds(mediaIds: List<Long>, type: MediaType): List<MediaMetadata> = dao.getByIds(mediaIds, type)
     suspend fun getByType(type: MediaType): List<MediaMetadata> = dao.getByType(type)
 
     suspend fun getByTag(tagId: Long): List<MediaMetadata> = dao.getByTag(tagId)
@@ -58,7 +57,7 @@ class MediaMetadataRepository(
     suspend fun deleteByTag(tagId: Long) = dao.deleteByTag(tagId)
     suspend fun deleteByCluster(clusterId: Long) = dao.deleteByCluster(clusterId)
 
-    suspend fun deleteByMediaIds(ids: List<Long>) = dao.deleteByIds(ids)
+    suspend fun deleteByMediaIds(ids: List<Long>, type: MediaType) = dao.deleteByIds(ids, type)
 
     suspend fun clear() = dao.clear()
 }

--- a/app/src/main/java/com/fpf/smartscan/data/migrations/MIGRATION_3_4.kt
+++ b/app/src/main/java/com/fpf/smartscan/data/migrations/MIGRATION_3_4.kt
@@ -5,24 +5,69 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 
 val MIGRATION_3_4 = object : Migration(3, 4) {
     override fun migrate(db: SupportSQLiteDatabase) {
+
+        // 1. Recreate media_metadata (TEXT type -> INTEGER type, single PK -> composite PK)
         db.execSQL(
             """
-            ALTER TABLE media_metadata
-            ADD COLUMN description TEXT
+            CREATE TABLE media_metadata_new (
+                id INTEGER NOT NULL,
+                type INTEGER NOT NULL,
+                dateAdded INTEGER NOT NULL,
+                description TEXT,
+                PRIMARY KEY(id, type)
+            )
             """.trimIndent()
         )
 
         db.execSQL(
             """
+            INSERT INTO media_metadata_new (id, type, dateAdded, description)
+            SELECT
+                id,
+                CASE
+                    WHEN type = 'IMAGE' THEN 0
+                    WHEN type = 'VIDEO' THEN 1
+                END,
+                dateAdded,
+                NULL
+            FROM media_metadata
+            """.trimIndent()
+        )
+
+        db.execSQL("DROP TABLE media_metadata")
+
+        db.execSQL(
+            "ALTER TABLE media_metadata_new RENAME TO media_metadata"
+        )
+
+        db.execSQL(
+            """
+            CREATE INDEX index_media_metadata_dateAdded
+            ON media_metadata(dateAdded)
+            """.trimIndent()
+        )
+
+        db.execSQL(
+            """
+            CREATE INDEX index_media_metadata_type_dateAdded
+            ON media_metadata(type, dateAdded)
+            """.trimIndent()
+        )
+
+
+        // 2. Recreate media_cluster_crossref
+        db.execSQL(
+            """
             CREATE TABLE media_cluster_crossref_new (
                 mediaId INTEGER NOT NULL,
+                mediaType INTEGER NOT NULL,
                 clusterId INTEGER NOT NULL,
-                PRIMARY KEY(mediaId),
+                PRIMARY KEY(mediaId, mediaType),
                 FOREIGN KEY(clusterId)
                     REFERENCES cluster_metadata(clusterId)
                     ON DELETE CASCADE,
-                FOREIGN KEY(mediaId)
-                    REFERENCES media_metadata(id)
+                FOREIGN KEY(mediaId, mediaType)
+                    REFERENCES media_metadata(id, type)
                     ON DELETE CASCADE
             )
             """.trimIndent()
@@ -30,21 +75,86 @@ val MIGRATION_3_4 = object : Migration(3, 4) {
 
         db.execSQL(
             """
-            INSERT INTO media_cluster_crossref_new (mediaId, clusterId)
-            SELECT mediaId, clusterId
-            FROM media_cluster_crossref
+            INSERT INTO media_cluster_crossref_new (
+                mediaId,
+                mediaType,
+                clusterId
+            )
+            SELECT
+                crc.mediaId,
+                mm.type,
+                crc.clusterId
+            FROM media_cluster_crossref crc
+            JOIN media_metadata mm
+                ON crc.mediaId = mm.id
             """.trimIndent()
         )
 
         db.execSQL("DROP TABLE media_cluster_crossref")
+
         db.execSQL(
-            "ALTER TABLE media_cluster_crossref_new RENAME TO media_cluster_crossref"
+            """
+            ALTER TABLE media_cluster_crossref_new
+            RENAME TO media_cluster_crossref
+            """.trimIndent()
         )
 
         db.execSQL(
             """
             CREATE INDEX index_media_cluster_crossref_clusterId
             ON media_cluster_crossref(clusterId)
+            """.trimIndent()
+        )
+
+
+        // 3. Recreate tag_crossref
+        db.execSQL(
+            """
+            CREATE TABLE tag_crossref_new (
+                mediaId INTEGER NOT NULL,
+                mediaType INTEGER NOT NULL,
+                tagId INTEGER NOT NULL,
+                PRIMARY KEY(mediaId, mediaType, tagId),
+                FOREIGN KEY(tagId)
+                    REFERENCES media_tag(id)
+                    ON DELETE CASCADE,
+                FOREIGN KEY(mediaId, mediaType)
+                    REFERENCES media_metadata(id, type)
+                    ON DELETE CASCADE
+            )
+            """.trimIndent()
+        )
+
+        db.execSQL(
+            """
+            INSERT INTO tag_crossref_new (
+                mediaId,
+                mediaType,
+                tagId
+            )
+            SELECT
+                tr.mediaId,
+                mm.type,
+                tr.tagId
+            FROM tag_crossref tr
+            JOIN media_metadata mm
+                ON tr.mediaId = mm.id
+            """.trimIndent()
+        )
+
+        db.execSQL("DROP TABLE tag_crossref")
+
+        db.execSQL(
+            """
+            ALTER TABLE tag_crossref_new
+            RENAME TO tag_crossref
+            """.trimIndent()
+        )
+
+        db.execSQL(
+            """
+            CREATE INDEX index_tag_crossref_tagId
+            ON tag_crossref(tagId)
             """.trimIndent()
         )
     }

--- a/app/src/main/java/com/fpf/smartscan/data/tags/TagCrossRef.kt
+++ b/app/src/main/java/com/fpf/smartscan/data/tags/TagCrossRef.kt
@@ -3,8 +3,6 @@ package com.fpf.smartscan.data.tags
 import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
-import androidx.room.TypeConverters
-import com.fpf.smartscan.data.MediaTypeConverter
 import com.fpf.smartscan.data.metadata.MediaMetadata
 import com.fpf.smartscan.media.MediaType
 
@@ -29,7 +27,6 @@ import com.fpf.smartscan.media.MediaType
         Index(value = ["tagId"]),
     ]
 )
-@TypeConverters(MediaTypeConverter::class)
 data class TagCrossRef(
     val mediaId: Long,
     val mediaType: MediaType,

--- a/app/src/main/java/com/fpf/smartscan/data/tags/TagCrossRef.kt
+++ b/app/src/main/java/com/fpf/smartscan/data/tags/TagCrossRef.kt
@@ -10,7 +10,7 @@ import com.fpf.smartscan.media.MediaType
 
 @Entity(
     tableName = "tag_crossref",
-    primaryKeys = ["mediaId", "tagId"],
+    primaryKeys = ["mediaId", "mediaType", "tagId"],
     foreignKeys = [
         ForeignKey(
             entity = Tag::class,
@@ -20,15 +20,18 @@ import com.fpf.smartscan.media.MediaType
         ),
         ForeignKey(
             entity = MediaMetadata::class,
-            parentColumns = ["id"],
-            childColumns = ["mediaId"],
+            parentColumns = ["id", "type"],
+            childColumns = ["mediaId", "mediaType"],
             onDelete = ForeignKey.CASCADE
         )
     ],
-    indices = [Index("tagId")]
+    indices = [
+        Index(value = ["tagId"]),
+    ]
 )
 @TypeConverters(MediaTypeConverter::class)
 data class TagCrossRef(
     val mediaId: Long,
-    val tagId: Long,
+    val mediaType: MediaType,
+    val tagId: Long
 )

--- a/app/src/main/java/com/fpf/smartscan/data/tags/TagCrossRefDao.kt
+++ b/app/src/main/java/com/fpf/smartscan/data/tags/TagCrossRefDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import com.fpf.smartscan.media.MediaType
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -18,12 +19,8 @@ interface TagCrossRefDao {
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insert(tags: List<TagCrossRef>)
 
-    @Query("DELETE FROM tag_crossref WHERE mediaId IN (:mediaIds)")
-    suspend fun deleteByMediaIds(mediaIds: List<Long>)
-
-    @Query("DELETE FROM tag_crossref WHERE mediaId IN (:mediaIds) AND tagId = :tagId")
-    suspend fun deleteMediaMatchingTag(mediaIds: List<Long>, tagId: Long)
-
+    @Query(""" DELETE FROM tag_crossref WHERE mediaId IN (:mediaIds) AND mediaType = :mediaType AND tagId = :tagId """)
+    suspend fun deleteMediaMatchingTag(mediaIds: List<Long>, mediaType: MediaType, tagId: Long)
     @Query("DELETE FROM tag_crossref WHERE tagId IN (:tagIds)")
     suspend fun deleteByTags(tagIds: List<Long>)
 

--- a/app/src/main/java/com/fpf/smartscan/data/tags/TagCrossRefRepository.kt
+++ b/app/src/main/java/com/fpf/smartscan/data/tags/TagCrossRefRepository.kt
@@ -1,13 +1,13 @@
 package com.fpf.smartscan.data.tags
 
+import com.fpf.smartscan.media.MediaType
 import kotlinx.coroutines.flow.Flow
 
 class TagCrossRefRepository(private val dao: TagCrossRefDao) {
      suspend fun getAllCrossRefs(): List<TagCrossRef> = dao.getAllCrossRefs()
      suspend fun getTagsForMedia(mediaId: Long): List<Long> = dao.getTagsForMedia(mediaId)
      suspend fun insertTagCrossRefs(crossRefs: List<TagCrossRef>) = dao.insert(crossRefs)
-     suspend fun deleteByMediaIds(ids: List<Long>) = dao.deleteByMediaIds(ids)
-     suspend fun deleteMediaMatchTag(ids: List<Long>, tagId: Long) = dao.deleteMediaMatchingTag(ids, tagId)
+     suspend fun deleteMediaMatchTag(ids: List<Long>, tagId: Long, mediaType: MediaType) = dao.deleteMediaMatchingTag(ids, mediaType, tagId)
      suspend fun clear() = dao.clear()
      fun getTagsWithCounts(): Flow<List<TagWithCount>> = dao.getTagCounts()
 }

--- a/app/src/main/java/com/fpf/smartscan/media/MediaErrorHandler.kt
+++ b/app/src/main/java/com/fpf/smartscan/media/MediaErrorHandler.kt
@@ -19,10 +19,10 @@ suspend fun onMediaLoadingError( error: AsyncImagePainter.State.Error, imageEmbe
             val id = ContentUris.parseId(uri as Uri)
             val idsToRemove = listOf(id)
             if(uri.toString().startsWith(MediaStore.Images.Media.EXTERNAL_CONTENT_URI.toString())){
-               removeStaleMedia(idsToRemove, imageEmbedStore, mediaMetadataRepository)
+               removeStaleMedia(idsToRemove, MediaType.IMAGE, imageEmbedStore, mediaMetadataRepository)
                 Log.e("MediaError", "Inaccessible Image URI deleted: $uri ", throwable)
             }else if(uri.toString().startsWith(MediaStore.Video.Media.EXTERNAL_CONTENT_URI.toString())){
-                removeStaleMedia(idsToRemove, videoEmbedStore, mediaMetadataRepository)
+                removeStaleMedia(idsToRemove, MediaType.VIDEO, videoEmbedStore, mediaMetadataRepository)
                 Log.e(TAG, "Inaccessible Video URI deleted: $uri ", throwable)
             }
         }
@@ -33,9 +33,9 @@ suspend fun onMediaLoadingError( error: AsyncImagePainter.State.Error, imageEmbe
     }
 }
 
-suspend fun removeStaleMedia(idsToPurge: List<Long>, store: FileEmbeddingStore, mediaMetadataRepository:MediaMetadataRepository){
+suspend fun removeStaleMedia(idsToPurge: List<Long>, type: MediaType, store: FileEmbeddingStore, mediaMetadataRepository:MediaMetadataRepository){
     store.remove(idsToPurge)
-    mediaMetadataRepository.deleteByMediaIds(idsToPurge)
-    mediaMetadataRepository.deleteByMediaIds(idsToPurge)
+    mediaMetadataRepository.deleteByMediaIds(idsToPurge, type)
+    mediaMetadataRepository.deleteByMediaIds(idsToPurge, type)
 }
 

--- a/app/src/main/java/com/fpf/smartscan/media/MediaType.kt
+++ b/app/src/main/java/com/fpf/smartscan/media/MediaType.kt
@@ -1,5 +1,6 @@
 package com.fpf.smartscan.media
 
-enum class MediaType {
-    IMAGE, VIDEO
+enum class MediaType(val code: Int) {
+    IMAGE(0),
+    VIDEO(1)
 }

--- a/app/src/main/java/com/fpf/smartscan/tag/TagManager.kt
+++ b/app/src/main/java/com/fpf/smartscan/tag/TagManager.kt
@@ -63,9 +63,11 @@ class TagManager(
         tag?.let { tagRepository.updateTags(listOf((it).copy(name = newName))) }
     }
 
-    suspend fun removeItems(tagName: String, mediaIds: List<Long>) {
+    suspend fun removeItems(tagName: String, items: Set<MediaItem>) {
         val tag = tagRepository.getTagsByName(listOf(tagName)).firstOrNull() ?: return
-        tagCrossRefRepository.deleteMediaMatchTag(mediaIds, tag.id)
+        items.groupBy { it.type }.forEach { (type, items) ->
+            tagCrossRefRepository.deleteMediaMatchTag(items.map{it.id}, tag.id, type)
+        }
     }
 
     suspend fun mergeTags(primaryTagName: String, otherTags: List<String>){
@@ -94,7 +96,9 @@ class TagManager(
         tagCrossRefRepository.insertTagCrossRefs(updatedCrossRef)
 
         val currentTag = tagRepository.getTagsByName(listOf(currentTagName)).firstOrNull()?: return
-        tagCrossRefRepository.deleteMediaMatchTag(  items.map{it.id}, currentTag.id)
+        items.groupBy { it.type }.forEach { (type, items) ->
+            tagCrossRefRepository.deleteMediaMatchTag(  items.map{it.id}, currentTag.id, type)
+        }
     }
 
     suspend fun toCollections(tags: List<TagWithCount>): List<MediaCollection> {

--- a/app/src/main/java/com/fpf/smartscan/tag/TagManager.kt
+++ b/app/src/main/java/com/fpf/smartscan/tag/TagManager.kt
@@ -23,7 +23,7 @@ class TagManager(
         if(id == null){
             id = tagRepository.insertTags(listOf(Tag(name = tagName.trim()))).first()
         }
-        val tagEntries = items.map { TagCrossRef(mediaId = it.id, tagId = id) }
+        val tagEntries = items.map { TagCrossRef(mediaId = it.id, tagId = id, mediaType = it.type) }
         tagCrossRefRepository.insertTagCrossRefs(tagEntries)
     }
 
@@ -73,7 +73,7 @@ class TagManager(
         val tagsToMerge = tagRepository.getTagsByName(otherTags)
         val mediaToUpdate = tagsToMerge.flatMap { mediaMetadataRepository.getByTag(it.id) }
         if(primaryTag != null && mediaToUpdate.isNotEmpty()){
-            val updated = mediaToUpdate.map{ TagCrossRef(mediaId = it.id, tagId = primaryTag.id) }
+            val updated = mediaToUpdate.map{ TagCrossRef(mediaId = it.id, tagId = primaryTag.id, mediaType = it.type) }
             tagCrossRefRepository.insertTagCrossRefs(updated)
             tagRepository.deleteTags(tagsToMerge)
         }
@@ -90,7 +90,7 @@ class TagManager(
     }
 
     private suspend fun moveItems(items: Set<MediaItem>, currentTagName: String, destinationTagId: Long){
-        val updatedCrossRef = items.map{ TagCrossRef(mediaId = it.id, tagId = destinationTagId) }
+        val updatedCrossRef = items.map{ TagCrossRef(mediaId = it.id, tagId = destinationTagId, mediaType = it.type) }
         tagCrossRefRepository.insertTagCrossRefs(updatedCrossRef)
 
         val currentTag = tagRepository.getTagsByName(listOf(currentTagName)).firstOrNull()?: return

--- a/app/src/main/java/com/fpf/smartscan/ui/screens/collections/CollectionItemsViewModel.kt
+++ b/app/src/main/java/com/fpf/smartscan/ui/screens/collections/CollectionItemsViewModel.kt
@@ -235,7 +235,7 @@ class CollectionItemsViewModel(
                 val selectedItems = getSelectedItems()
                 if (selectedItems.isEmpty()) return@launch
                 when(newCollection.type) {
-                    CollectionType.CLUSTER -> clusterManager.moveItems(selectedItems.map{it.id}, newCollection.id, currentCollection.id)
+                    CollectionType.CLUSTER -> clusterManager.moveItems(selectedItems, newCollection.id, currentCollection.id)
                     CollectionType.TAG -> tagManager.moveItems(selectedItems, currentCollection.name, newCollection.name)
                 }
                 resetSelection()

--- a/app/src/main/java/com/fpf/smartscan/ui/screens/collections/CollectionItemsViewModel.kt
+++ b/app/src/main/java/com/fpf/smartscan/ui/screens/collections/CollectionItemsViewModel.kt
@@ -213,7 +213,7 @@ class CollectionItemsViewModel(
 
         viewModelScope.launch (Dispatchers.IO){
             try {
-                val selectedItems = getSelectedItems().map{it.id}
+                val selectedItems = getSelectedItems()
                 tagManager.removeItems(currentCollection.name, selectedItems)
                 resetSelection()
                 val message = if(selectedItems.size == 1 ) "Removed ${selectedItems.size} item" else "Removed ${selectedItems.size} items"

--- a/app/src/main/java/com/fpf/smartscan/ui/screens/search/SearchViewModel.kt
+++ b/app/src/main/java/com/fpf/smartscan/ui/screens/search/SearchViewModel.kt
@@ -315,7 +315,7 @@ class SearchViewModel(
 
     private fun purgeStaleItems(store: FileEmbeddingStore, idsToPurge: List<Long>){
         viewModelScope.launch(Dispatchers.IO) {
-            removeStaleMedia(idsToPurge, store, mediaMetadataRepository)
+            removeStaleMedia(idsToPurge, _state.value.mediaType, store, mediaMetadataRepository)
         }
     }
 
@@ -413,7 +413,7 @@ class SearchViewModel(
 
     private suspend fun getAllResults(): MutableSet<MediaItem> {
         return withContext(Dispatchers.IO) {
-            val mediaMetadataList = mediaMetadataRepository.getByIds(cachedIds)
+            val mediaMetadataList = mediaMetadataRepository.getByIds(cachedIds, _state.value.mediaType)
             mediaMetadataList.map {
                 MediaItem(
                     id = it.id,


### PR DESCRIPTION
Previously, id was the primary key, where id  corresponds to the image or video MediaStore Id, which could be the same. This collision would be a silently ignored because insertion policy is set to ignore conflicts. Using the composite key prevents collisions.